### PR TITLE
Update README: add SHA-1 checking example, change copyright year

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Puppet module to download files with curl, supporting authentication.
 	  destination => "/tmp/index.html",
 	  timeout     => 0,
 	  verbose     => false,
+    sha         => "F79B40AEBC81B822F6096D606098CDA62C1997CD",
 	}
 	
 	curl::authfetch { "download":

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A Puppet module to download files with curl, supporting authentication.
 
 # License
 
-Copyright (c) 2013 Government Digital Services
+Copyright (c) 2015 Government Digital Service
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updates the README to:
- add an example of how to check a SHA-1 of a file
- change the copyright year in the LICENSE paragraph