### PR TITLE
If given a SHA use that to test.

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -20,18 +20,26 @@ define curl::fetch($source,$destination,$timeout='0',$verbose=false,$sha=undef) 
     false => '--silent --show-error'
   }
 
+  if $sha {
+    $unless = "test \"`shasum $destination`\" = \"$sha  $destination\""
+  }
+  else {
+    $unless = "test -s $destination"
+  }
+
   exec { "curl-$name":
     command     => "curl $verbose_option -L --output $destination $source",
     timeout     => $timeout,
-    unless      => "test -s $destination",
+    unless      => $unless,
     environment => $environment,
     path        => '/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin',
     require     => Class[curl],
   }
 
   if $sha != undef {
-    exec { 'curl-sha-$name':
-      command => "test \"`shasum $destination`\" = \"$sha  $destination\"",
+    exec { "curl-sha-$name":
+      command => $unless,
+      unless  => $unless,
       require => Exec["curl-$name"],
     }
   }


### PR DESCRIPTION
If we are passed a SHA we should use that to test that any previously
downloaded file is correct and not just rely on its existence.

Also, set an unless on the SHA exec so that it doesnt execute everytime if
the SHA is correct causing other resources to be possibly notified.