### PR TITLE
Add parameters redownload and onlyif

### DIFF
--- a/manifests/authfetch.pp
+++ b/manifests/authfetch.pp
@@ -6,8 +6,17 @@
 # password must be stored in the password variable within the .curlrc file.
 #
 ################################################################################
-define curl::authfetch($source,$destination,$user,$password='',$timeout='0',$verbose=false) {
+define curl::authfetch(
+  $source,
+  $destination,
+  $user,
+  $password = '',
+  $timeout = '0',
+  $verbose = false
+) {
+
   include curl
+
   if $::http_proxy {
     $environment = [ "HTTP_PROXY=${::http_proxy}", "http_proxy=${::http_proxy}" ]
   }

--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -5,7 +5,14 @@
 # using $http_proxy if necessary.
 #
 ################################################################################
-define curl::fetch($source,$destination,$timeout='0',$verbose=false,$sha=undef) {
+define curl::fetch(
+  $source,
+  $destination,
+  $timeout = '0',
+  $verbose = false,
+  $sha = undef,
+) {
+
   include curl
 
   if $::http_proxy {
@@ -35,5 +42,4 @@ define curl::fetch($source,$destination,$timeout='0',$verbose=false,$sha=undef) 
       require => Exec["curl-$name"],
     }
   }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,8 +4,10 @@
 # This class will install curl - a tool used to download content from the web.
 #
 ################################################################################
-class curl($version='installed') {
+class curl(
+  $version = 'installed'
+) {
 
-    package { 'curl': ensure => $version }
+  package { 'curl': ensure => $version }
 
 }


### PR DESCRIPTION
## Add two more parameters to control download behavior.
### redownload
- If true, the file will be downloaded no matter if it is already existing or not.
### onlyif
- If set to 'not_existing', the file will only be downloaded if it is not yet existing.  
  Since this is the default, this change is backwards compatible.
- If set to 'modified', the file will only be downloaded, if the file from the server is newer then the local one.
