### PR TITLE
Strict fixes

### DIFF
--- a/manifests/authfetch.pp
+++ b/manifests/authfetch.pp
@@ -8,10 +8,10 @@
 ################################################################################
 define curl::authfetch($source,$destination,$user,$password='',$timeout='0',$verbose=false) {
   include curl
-  if $::http_proxy {
+
+  if defined('$::http_proxy') and $::http_proxy != undef {
     $environment = [ "HTTP_PROXY=${::http_proxy}", "http_proxy=${::http_proxy}" ]
-  }
-  else {
+  } else {
     $environment = []
   }
 

--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -8,10 +8,9 @@
 define curl::fetch($source,$destination,$timeout='0',$verbose=false,$sha=undef) {
   include curl
 
-  if $::http_proxy {
+  if defined('$::http_proxy') and $::http_proxy != undef {
     $environment = [ "HTTP_PROXY=${::http_proxy}", "http_proxy=${::http_proxy}" ]
-  }
-  else {
+  } else {
     $environment = []
   }
 

--- a/spec/defines/curl__authfetch_spec.rb
+++ b/spec/defines/curl__authfetch_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'curl::authfetch', :type => :define do
+  let(:title) { 'a_file' }
+
+  let(:params) { {
+    :source      => '127.0.0.1:80',
+    :destination => '/tmp/files',
+    :user        => 'deploy',
+  } }
+
+  context 'without proxies' do
+    it { is_expected.to contain_exec('curl-a_file').with_environment [] }
+  end
+
+  context 'with proxies' do
+    let(:facts) { {
+      :http_proxy => '127.0.0.1:8888'
+    } }
+
+    it { is_expected.to contain_exec('curl-a_file').with_environment /HTTP/ }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,6 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet'
+
+RSpec.configure do |c|
+  c.strict_variables = true
+end


### PR DESCRIPTION
This module doesn't currently pass spec tests when run under strict_variables. The new code adds a check for that mode being enabled and handles the case where `http_proxy` is not set more gracefully.

This code is heavily stolen from https://github.com/maestrodev/puppet-wget/blob/14b00e64c4d990d18a7b20f0e7098956c55806c5/manifests/fetch.pp#L37