### PR TITLE
Add escaping to the URL, to support & in the URL.

### DIFF
--- a/manifests/authfetch.pp
+++ b/manifests/authfetch.pp
@@ -26,7 +26,7 @@ define curl::authfetch($source,$destination,$user,$password='',$timeout='0',$ver
     content => "user = ${user}:${password}",
   } ->
   exec { "curl-${name}":
-    command     => "curl ${verbose_option} --config /tmp/curlrc-${name} --output ${destination} ${source}",
+    command     => "curl ${verbose_option} --config /tmp/curlrc-${name} --output ${destination} '${source}'",
     timeout     => $timeout,
     unless      => "test -s ${destination}",
     environment => $environment,

--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -20,7 +20,7 @@ define curl::fetch($source,$destination,$timeout='0',$verbose=false,$sha=undef) 
   }
 
   exec { "curl-${name}":
-    command     => "curl ${verbose_option} -L --output ${destination} ${source}",
+    command     => "curl ${verbose_option} -L --output ${destination} '${source}'",
     timeout     => $timeout,
     unless      => "test -s ${destination}",
     environment => $environment,


### PR DESCRIPTION
At the moment, this module does not allow & (or other allowed chars) to be in the URL.

This however, should be supported. By adding these quotes, this will be supported.

Tested on Debian and Ubuntu.